### PR TITLE
add sendable to support concurrency

### DIFF
--- a/Exercism.xcodeproj/project.pbxproj
+++ b/Exercism.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		FDE27F25298FC5CE00F61A0A /* ProfileTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTableView.swift; sourceTree = "<group>"; };
 		FDE4EBFB2A4B009C007ED19E /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		FDEF2CDA2A2870F500965E8C /* AsyncModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncModel.swift; sourceTree = "<group>"; };
+		FDFBF6CD2BA449FE0032AEF1 /* ExercismSwift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = ExercismSwift; path = ../ExercismSwift; sourceTree = "<group>"; };
 		FDFF5A802A66C2E700E36AA4 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
 		FDFF5A822A66C31A00E36AA4 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -196,6 +197,7 @@
 		E0C9672328732A44004CE7E6 = {
 			isa = PBXGroup;
 			children = (
+				FDFBF6CD2BA449FE0032AEF1 /* ExercismSwift */,
 				FDB011B52AF8F6A700D29F77 /* project.xcconfig */,
 				E0C9672E28732A44004CE7E6 /* Exercism */,
 				E0C9672D28732A44004CE7E6 /* Products */,
@@ -725,7 +727,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 2.0.0;
 			};
 		};
@@ -733,7 +735,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/JohnSundell/Splash";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 0.16.0;
 			};
 		};
@@ -741,7 +743,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ZeeZide/CodeEditor.git";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 1.0.0;
 			};
 		};
@@ -749,8 +751,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/Settings";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		FDC9F11D28E5DA9200488CE9 /* XCRemoteSwiftPackageReference "keychain-swift" */ = {
@@ -773,8 +775,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImageSVGCoder.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = master;
+				kind = branch;
 			};
 		};
 		FDC9F12828E5E86500488CE9 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {

--- a/Exercism.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Exercism.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,17 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ZeeZide/CodeEditor.git",
       "state" : {
-        "revision" : "180bde07b44dea839b32873bd8586ba146fa9106",
-        "version" : "1.2.2"
-      }
-    },
-    {
-      "identity" : "exercismswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apps-fab/ExercismSwift",
-      "state" : {
-        "branch" : "main",
-        "revision" : "4b34014b65c833e128b0c9d82bd23b2b73a0a3c9"
+        "revision" : "7ec02043f10961cb44db54d2b488525ed36f40a3",
+        "version" : "1.0.0"
       }
     },
     {
@@ -33,7 +24,7 @@
       "location" : "https://github.com/evgenyneu/keychain-swift.git",
       "state" : {
         "branch" : "master",
-        "revision" : "6b6fc468877a5f01fe211fcf0af840b9ecce9d98"
+        "revision" : "d0ef1ecaabcb01bc5c3d10b685cd9fcc0f1d7fd3"
       }
     },
     {
@@ -42,7 +33,7 @@
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
         "branch" : "master",
-        "revision" : "59730af512c06fb569c119d737df4c1c499e001d"
+        "revision" : "f6afa0132961d593f07970d84e2d8b588c29ea04"
       }
     },
     {
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImageSVGCoder.git",
       "state" : {
-        "revision" : "afbe025cbdae37c20c144956fbabc07ddd5c0fc2",
-        "version" : "1.6.1"
+        "branch" : "master",
+        "revision" : "6de587af4f5b775c18665b90b86bec0ba7a4ac4e"
       }
     },
     {
@@ -60,7 +51,7 @@
       "location" : "https://github.com/SDWebImage/SDWebImageSwiftUI.git",
       "state" : {
         "branch" : "master",
-        "revision" : "79961a5ac3ea7a3253ff643291ff3c158777029c"
+        "revision" : "22423b017b99ab8ac44e29e6372f571f782af6e4"
       }
     },
     {
@@ -68,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/Settings",
       "state" : {
-        "revision" : "b99f45cba818a9d483fb58e9b31de5dee799e315",
-        "version" : "3.0.3"
+        "branch" : "main",
+        "revision" : "2f4f65eed252198be383aa0d9058bbaf8f740aa5"
       }
     },
     {
@@ -86,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
       "state" : {
-        "revision" : "12b351a75201a8124c2f2e1f9fc6ef5cd812c0b9",
-        "version" : "2.1.0"
+        "revision" : "4392c3cefd08db10f13ffb019d7c7a4a622824f5",
+        "version" : "2.0.2"
       }
     }
   ],

--- a/Exercism/AsyncModel.swift
+++ b/Exercism/AsyncModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import ExercismSwift
 
-enum LoadingState<Value> {
+enum LoadingState<Value: Sendable> {
     case idle
     case loading
     case success(Value)
@@ -17,14 +17,14 @@ enum LoadingState<Value> {
 
 @MainActor
 protocol LoadableObject: ObservableObject {
-    associatedtype Value
+    associatedtype Value: Sendable
     
     var state: LoadingState<Value> { get }
     func load() async
 }
 
 @MainActor
-class AsyncModel<Value>: ObservableObject, LoadableObject {
+class AsyncModel<Value: Sendable>: ObservableObject, LoadableObject {
     @Published private(set) var state: LoadingState<Value> = LoadingState.idle
     typealias AsyncOperation = () async throws -> Value
     typealias SyncOperation = () -> Value

--- a/Exercism/Authentication/AuthenticationViewModel.swift
+++ b/Exercism/Authentication/AuthenticationViewModel.swift
@@ -8,13 +8,13 @@
 import Foundation
 import ExercismSwift
 
+@MainActor
 final class AuthenticationViewModel: ObservableObject {
     @Published var tokenInput = ""
     @Published var isLoading = false
     @Published var showAlert = false
     @Published var error: String?
     
-    @MainActor
     func validateToken() async -> Bool {
         guard !tokenInput.isEmpty else {
             error = Strings.tokenEmptyWarning.localized()

--- a/Exercism/Exercises/ExerciseEditorView.swift
+++ b/Exercism/Exercises/ExerciseEditorView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import CodeEditor
+@preconcurrency import CodeEditor
 
 struct ExerciseEditorView: View {
     @State private var exerciseViewModel = ExerciseViewModel.shared

--- a/Exercism/ExercismSettings.swift
+++ b/Exercism/ExercismSettings.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 import Settings
-import CodeEditor
+@preconcurrency import CodeEditor
 import Splash
 
+@MainActor
 let exercismSettingsScreen: () -> SettingsPane  = {
     let paneView = Settings.Pane(
         identifier: .general,

--- a/Exercism/Models/SettingData.swift
+++ b/Exercism/Models/SettingData.swift
@@ -3,7 +3,7 @@
 //
 
 import Foundation
-import CodeEditor
+@preconcurrency import CodeEditor
 
 class SettingData: ObservableObject {
     @Published var theme = CodeEditor.ThemeName.pojoaque

--- a/Exercism/SideBar.swift
+++ b/Exercism/SideBar.swift
@@ -36,6 +36,7 @@ struct SideBar: View {
         }
     }
 
+    @MainActor
     private func logout() {
         ExercismKeychain.shared.removeItem(for: Keys.token.rawValue)
         navigationModel.goToLogin()

--- a/Exercism/Util/AppDelegate.swift
+++ b/Exercism/Util/AppDelegate.swift
@@ -9,6 +9,7 @@ import AppKit
 import Settings
 import ExercismSwift
 
+@MainActor
 extension Settings.PaneIdentifier {
     static let general = Self("General")
     static let advanced = Self("Advanced")
@@ -19,7 +20,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         true
     }
 
-    // What's this is for???
     private lazy var panes: [SettingsPane]  = [
         exercismSettingsScreen()
     ]

--- a/Exercism/Util/ContentView.swift
+++ b/Exercism/Util/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
     @StateObject private var navigationModel = NavigationModel()
     @SceneStorage("navigation") private var navigationData: Data?
     private let model = TrackModel.shared
-    
+
     var body: some View {
         NavigationStack(path: $navigationModel.path) {
             ZStack {
@@ -29,42 +29,41 @@ struct ContentView: View {
             minHeight: 500, idealHeight: 800, maxHeight: .infinity
         )
     }
-    
+
     @Sendable
     private func performInitialNavigationSetup() async {
         if let navigationData {
             navigationModel.jsonData = navigationData
         }
-        
+
         // User is logged in but navigationModel path is empty
         if ExercismKeychain.shared.get(for: Keys.token.rawValue) != nil && navigationModel.path.isEmpty {
             navigationModel.goToDashboard()
             // Save navigation data into scene storage
             navigationData = navigationModel.jsonData
         }
-        
+
         for await _ in navigationModel.objectWillChangeSequence {
             navigationData = navigationModel.jsonData
         }
     }
 
-    
     @ViewBuilder
     private func handleDestinationRoute(_ route: Route) -> some View {
         switch route {
         case let .Exercise(track, exercise, solution):
             ExerciseEditorWindowView(asyncModel: AsyncModel(operation: { try await ExerciseViewModel.shared.getDocument(track, exercise) } ), solution: solution)
                 .environmentObject(navigationModel)
-            
+
         case let .Track(track):
             ExercisesList(track: track,
                           asyncModel: .init { try await model.getExercises(track) })
             .environmentObject(navigationModel)
-            
+
         case .Login:
             LoginView()
                 .environmentObject(navigationModel)
-            
+
         case .Dashboard:
             TracksListView(asyncModel: .init { try await model.getTracks() })
                 .environmentObject(navigationModel)

--- a/Exercism/Util/ExercismApp.swift
+++ b/Exercism/Util/ExercismApp.swift
@@ -19,7 +19,7 @@ struct ExercismApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var settingsData = SettingData()
     @StateObject private var model = TrackModel.shared
-    
+
     init() {
         SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
     }

--- a/Exercism/Util/KeychainHelper.swift
+++ b/Exercism/Util/KeychainHelper.swift
@@ -5,10 +5,10 @@
 //  Created by Angie Mugo on 29/09/2022.
 //
 
-import KeychainSwift
+@preconcurrency import KeychainSwift
 
-class ExercismKeychain {
-    public static let shared = ExercismKeychain()
+final class ExercismKeychain: Sendable {
+   public static let shared = ExercismKeychain()
     private let keychain = KeychainSwift()
     
     func set(_ value: String, for key: String) {

--- a/Exercism/Util/Localizable.xcstrings
+++ b/Exercism/Util/Localizable.xcstrings
@@ -466,9 +466,6 @@
         }
       }
     },
-    "Mark as complete" : {
-
-    },
     "new" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -737,7 +734,7 @@
         }
       }
     },
-    "Some" : {
+    "Some %@" : {
 
     },
     "sortBy" : {
@@ -920,9 +917,6 @@
       }
     },
     "You can find your token on your [settings page](https://exercism.org/settings/api_cli)" : {
-
-    },
-    "You need to run the tests before submitting." : {
 
     }
   },

--- a/Exercism/Util/NavigationModel.swift
+++ b/Exercism/Util/NavigationModel.swift
@@ -12,20 +12,20 @@ import Combine
 
 enum Route: Hashable, Identifiable, Codable {
     var id: Self { return self }
-    
+
     case Track(Track)
     case Exercise(String, String, Solution?)
     case Login
     case Dashboard
 }
 
-class NavigationModel: ObservableObject, Codable {
+final class NavigationModel: ObservableObject, Codable {
     @Published var path: [Route]
     @Published var columnVisibility: NavigationSplitViewVisibility
-    
+
     private lazy var decoder = JSONDecoder()
     private lazy var encoder = JSONEncoder()
-    
+
     
     init(path: [Route] = [], columnVisibility: NavigationSplitViewVisibility = .automatic) {
         self.columnVisibility = columnVisibility
@@ -56,14 +56,14 @@ class NavigationModel: ObservableObject, Codable {
         
         self.columnVisibility = try container.decode(NavigationSplitViewVisibility.self, forKey: .columnVisibility)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        
+
         try container.encode(path, forKey: .path)
         try container.encode(columnVisibility, forKey: .columnVisibility)
     }
-    
+
     func goToDashboard() {
         path.append(Route.Dashboard)
     }
@@ -82,12 +82,12 @@ class NavigationModel: ObservableObject, Codable {
         path.append(Route.Login)
     }
 
-    func goBack() {
-        path.removeLast()
-    }
-    
     enum CodingKeys: String, CodingKey {
         case path
         case columnVisibility
     }
+}
+
+extension DispatchQueue {
+    static let pathMutatingLock = DispatchQueue(label: "person.lock.queue")
 }

--- a/Exercism/Util/ViewUtils.swift
+++ b/Exercism/Util/ViewUtils.swift
@@ -41,7 +41,7 @@ extension View {
         }
     }
 
-    public func tabItem<TabItem: Tabbable>(for item: TabItem) -> some View {
+    @MainActor public func tabItem<TabItem: Tabbable>(for item: TabItem) -> some View {
         return self.modifier(TabBarViewModifier(item: item))
     }
 }


### PR DESCRIPTION
- Sendable is Swift's way of handling concurrency
- After enabling strict checking I noticed some places in the codebase that had this warning 
- Since a lot of the libraries we are using haven't enforced the `sendable` protocol, I silenced those warnings by adding `preconcurrency`. 
- We still have a potential concurrency error with how we handle `performInitialNavigationSetup`.
- Here's the reference for this https://developer.apple.com/documentation/swift/sendable