### PR TITLE
Added Possible Refresh Shortcut

### DIFF
--- a/Exercism.xcodeproj/project.pbxproj
+++ b/Exercism.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		CB6F94942B4C27A1002F8A2C /* ExercismSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CB6F94932B4C27A1002F8A2C /* ExercismSwift */; };
 		CB8681242B51751F0059AB65 /* ExercismSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CB8681232B51751F0059AB65 /* ExercismSwift */; };
 		CB9DFA7F2AF97A1D0093566C /* AuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9DFA7E2AF97A1D0093566C /* AuthenticationViewModel.swift */; };
+		CBA63CF42BD7F1C700151C19 /* NSNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA63CF32BD7F1C700151C19 /* NSNotification.swift */; };
 		E049F22428E5766B0022CECD /* ExerciseRightSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E049F22328E5766B0022CECD /* ExerciseRightSidebarView.swift */; };
 		E07F6B0729E0D04D00E5C42A /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = E07F6B0629E0D04D00E5C42A /* MarkdownUI */; };
 		E07F6B0A29E0D5DA00E5C42A /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = E07F6B0929E0D5DA00E5C42A /* Splash */; };
@@ -85,6 +86,7 @@
 		CB370BC02B3618F400C1009D /* SubmitSolutionContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitSolutionContentView.swift; sourceTree = "<group>"; };
 		CB4F3C132B5EEB2300829CCD /* AlertModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertModel.swift; sourceTree = "<group>"; };
 		CB9DFA7E2AF97A1D0093566C /* AuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationViewModel.swift; sourceTree = "<group>"; };
+		CBA63CF32BD7F1C700151C19 /* NSNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSNotification.swift; sourceTree = "<group>"; };
 		E049F21928E4D7B30022CECD /* ExerciseEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseEditorView.swift; sourceTree = "<group>"; };
 		E049F22328E5766B0022CECD /* ExerciseRightSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseRightSidebarView.swift; sourceTree = "<group>"; };
 		E09BA7E928E4E83800D7CC91 /* ExerciseEditorWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExerciseEditorWindowView.swift; sourceTree = "<group>"; };
@@ -132,7 +134,6 @@
 		FDE27F25298FC5CE00F61A0A /* ProfileTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTableView.swift; sourceTree = "<group>"; };
 		FDE4EBFB2A4B009C007ED19E /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		FDEF2CDA2A2870F500965E8C /* AsyncModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncModel.swift; sourceTree = "<group>"; };
-		FDFBF6CD2BA449FE0032AEF1 /* ExercismSwift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = ExercismSwift; path = ../ExercismSwift; sourceTree = "<group>"; };
 		FDFF5A802A66C2E700E36AA4 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
 		FDFF5A822A66C31A00E36AA4 /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -197,7 +198,6 @@
 		E0C9672328732A44004CE7E6 = {
 			isa = PBXGroup;
 			children = (
-				FDFBF6CD2BA449FE0032AEF1 /* ExercismSwift */,
 				FDB011B52AF8F6A700D29F77 /* project.xcconfig */,
 				E0C9672E28732A44004CE7E6 /* Exercism */,
 				E0C9672D28732A44004CE7E6 /* Products */,
@@ -324,6 +324,7 @@
 				FD7DC52F29E0B00700A1EBD9 /* PreviewData.swift */,
 				FDFF5A822A66C31A00E36AA4 /* Strings.swift */,
 				FDFF5A802A66C2E700E36AA4 /* Images.swift */,
+				CBA63CF32BD7F1C700151C19 /* NSNotification.swift */,
 				FD9B57E82A8264AB0042C6B0 /* Localizable.xcstrings */,
 				FD9262FE28F6EA3300C9476C /* Tags.json */,
 				FD93F5D628E398770078A062 /* Date+Exercism.swift */,
@@ -459,6 +460,7 @@
 				E0F6E9BE2992236D0079CC28 /* TestRunResultView.swift in Sources */,
 				FD6FE8F22A95514E0043A89F /* ExerciseEditorView.swift in Sources */,
 				E049F22428E5766B0022CECD /* ExerciseRightSidebarView.swift in Sources */,
+				CBA63CF42BD7F1C700151C19 /* NSNotification.swift in Sources */,
 				E0C9673028732A44004CE7E6 /* ExercismApp.swift in Sources */,
 				FD36808029B1054E004D53C8 /* CustomPicker.swift in Sources */,
 				FD7DC53929E2CA6700A1EBD9 /* AsyncResultView.swift in Sources */,

--- a/Exercism.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Exercism.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "606437cca830a0d8fa742b7f6b3f182b5ae0ac63c431365750ac428d80c3fd92",
   "pins" : [
     {
       "identity" : "codeeditor",
@@ -7,6 +8,15 @@
       "state" : {
         "revision" : "7ec02043f10961cb44db54d2b488525ed36f40a3",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "exercismswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apps-fab/ExercismSwift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "03953c3e9bcd2035f593ee72ac6c122309c8f548"
       }
     },
     {
@@ -82,5 +92,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Exercism/AsyncModel.swift
+++ b/Exercism/AsyncModel.swift
@@ -29,7 +29,7 @@ class AsyncModel<Value: Sendable>: ObservableObject, LoadableObject {
     typealias AsyncOperation = () async throws -> Value
     typealias SyncOperation = () -> Value
     
-    var operation: AsyncOperation
+    private var operation: AsyncOperation
     var filterOperations: SyncOperation? {
         didSet {
             state = .success(filterOperations!())

--- a/Exercism/ExerciseList/ExerciseGridView.swift
+++ b/Exercism/ExerciseList/ExerciseGridView.swift
@@ -71,7 +71,7 @@ struct ExerciseGridView: View {
                 .foregroundStyle(.green)
             }
             
-            if let numIterations = solution?.numTterations,
+            if let numIterations = solution?.numIterations,
                numIterations > 0 {
                 // @Todo(Kirk) Convert this to stringdict for proper localisation)
                 let iterationText = "\(String(describing: numIterations)) \(numIterations == 1 ? "iteration" : "iterations")"

--- a/Exercism/Tracks/TracksListView.swift
+++ b/Exercism/Tracks/TracksListView.swift
@@ -91,7 +91,6 @@ struct TracksListView: View {
                             ) {
                                 ForEach(joinedTracks) { track in
                                     Button {
-                                        cancellable?.cancel()
                                         navigationModel.goToTrack(track)
                                     } label: {
                                         TrackGridView(track: track)

--- a/Exercism/Util/ContentView.swift
+++ b/Exercism/Util/ContentView.swift
@@ -20,7 +20,9 @@ struct ContentView: View {
                 }
             }
             .environmentObject(navigationModel)
-            .task(performInitialNavigationSetup)
+            .task {
+                await performInitialNavigationSetup()
+            }
             .navigationDestination(for: Route.self, destination: handleDestinationRoute)
             .navigationBarBackButtonHidden(false)
         }
@@ -30,7 +32,6 @@ struct ContentView: View {
         )
     }
 
-    @Sendable
     private func performInitialNavigationSetup() async {
         if let navigationData {
             navigationModel.jsonData = navigationData

--- a/Exercism/Util/ExercismApp.swift
+++ b/Exercism/Util/ExercismApp.swift
@@ -19,7 +19,7 @@ struct ExercismApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var settingsData = SettingData()
     @StateObject private var model = TrackModel.shared
-
+    
     init() {
         SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
     }
@@ -35,11 +35,21 @@ struct ExercismApp: App {
             ExercismCommands()
             CommandGroup(replacing: .appInfo) {
                 Button("About Exercism") {
-                    NSApplication.shared.orderFrontStandardAboutPanel(options: [NSApplication.AboutPanelOptionKey.credits: NSAttributedString(string: "Exercism is a software built off the Exercism web platform.",
-                                                                                                                                     attributes: [NSAttributedString.Key.font: NSFont.boldSystemFont(ofSize: NSFont.smallSystemFontSize)
-                                                                ]),
-                                                                       NSApplication.AboutPanelOptionKey(rawValue: "Copyright"): "© 2023"
-                    ] as [NSApplication.AboutPanelOptionKey : Any])
+                    NSApplication.shared.orderFrontStandardAboutPanel(
+                        options: [
+                            NSApplication.AboutPanelOptionKey.credits: NSAttributedString(
+                                string: "Exercism is a software built off the Exercism web platform.",
+                                attributes: [
+                                    NSAttributedString.Key.font: NSFont.boldSystemFont(
+                                        ofSize: NSFont.smallSystemFontSize
+                                    )
+                                ]
+                            ),
+                            NSApplication.AboutPanelOptionKey(
+                                rawValue: "Copyright"
+                            ): "© 2023"
+                        ] as [NSApplication.AboutPanelOptionKey : Any]
+                    )
                 }
                 
                 Button("Toggle Full Screen") {
@@ -49,6 +59,17 @@ struct ExercismApp: App {
                     }
                 }
                 .keyboardShortcut("F", modifiers: [.control, .command])
+                
+            }
+            
+            CommandGroup(before: .sidebar) {
+                Button("Refresh") {
+                    let notification = Notification(
+                        name: .didRequestRefresh,
+                        object: self)
+                    NotificationCenter.default.post(notification)
+                }
+                .keyboardShortcut("r")
             }
         }
         Settings {

--- a/Exercism/Util/ExercismApp.swift
+++ b/Exercism/Util/ExercismApp.swift
@@ -69,7 +69,7 @@ struct ExercismApp: App {
                         object: self)
                     NotificationCenter.default.post(notification)
                 }
-                .keyboardShortcut("r")
+                .keyboardShortcut("R")
             }
         }
         Settings {

--- a/Exercism/Util/Localizable.xcstrings
+++ b/Exercism/Util/Localizable.xcstrings
@@ -554,6 +554,9 @@
         }
       }
     },
+    "Refresh" : {
+
+    },
     "resetFilters" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Exercism/Util/NSNotification.swift
+++ b/Exercism/Util/NSNotification.swift
@@ -1,0 +1,14 @@
+//
+//  NSNotification.swift
+//  Exercism
+//
+//  Created by Cédric Bahirwe on 23/04/2024.
+//
+
+import Foundation
+
+extension NSNotification.Name {
+    static var didRequestRefresh: NSNotification.Name {
+        NSNotification.Name("didRequestRefresh")
+    }
+}


### PR DESCRIPTION
### Notable Changes:
- Added a refresh shortcut + button within the `View` menu, #53 
- Added `onReceive` modifier to handle refresh publisher event updates.
- Addressed a concurrency warning for Swift 6

### Insights:

- Although the current implementation appears devoid of any visible bugs, a challenge persists in limiting the refresh trigger exclusively to instances when the `TrackListView` is visible. Further refinement may be needed in future iterations.